### PR TITLE
Create Automatic Resource Pack Builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,32 @@
+name: Build Resource Pack
+
+on:
+  push:
+  pull_request:
+
+# if a second commit is pushed quickly after the first, cancel the first one's build
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build Resource Pack (${{ github.sha }})
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Ref
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Upload Resource Pack
+        uses: actions/upload-artifact@v4
+        with:
+          name: Faithful32-NomiLabs
+          path: |
+            ./pack.mcmeta
+            ./pack.png
+            ./assets/**/*
+          if-no-files-found: error
+          compression-level: 9

--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
-# Faithful32 NomiLabs
- 
+# Faithful32-NomiLabs
+
+WIP Faithful 32 resource pack for Nomi Labs (1.12.2).
+
+## Installation
+1. Download the Resource Pack from our [Nightly Page](https://nightly.link/marisathewitch/Faithful32-NomiLabs/workflows/build/main/Faithful32-NomiLabs).
+2. Place it into your instance's Resouce Pack Folder.
+3. Inside the game, place this Resource Pack above "F32 Modded" and "Faithful F32".


### PR DESCRIPTION
This PR simply creates automatic resource pack builds for every commit pushed to this repo. These builds do not have the problem of a 'folder inside a folder', so they work out of the box.

Please note:
- The nightly page link will not work until this PR is merged, and the workflow runs for the first time